### PR TITLE
Add lloydcenter.fun to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
   <b>~ Ring Members ~</b>
 
   &gt;&gt; <a href="https://readingstori.es">readingstori.es</a> -- books for a baby, semantic HTML experiment
+  &gt;&gt; <a href="https://lloydcenter.fun">lloydcenter.fun</a> -- fan page for Portland's gloriously weird half-empty mall
 </pre>
                         <center>
                             <a
@@ -187,7 +188,8 @@
         </center>
         <script>
             var members = [
-                "https://readingstori.es"
+                "https://readingstori.es",
+                "https://lloydcenter.fun"
             ];
             var n = members.length;
             document.getElementById("member-count").textContent = n + (n === 1 ? " member" : " members");


### PR DESCRIPTION
## Summary
- Add lloydcenter.fun to the ring members list and JS members array
- Fan page for Lloyd Center, Portland's gloriously weird half-empty mall
- Jazz Cup / Memphis 90s aesthetic, webring snippet is in the site footer

Closes #2