### PR TITLE
Add wiki-hn.com to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
 
   &gt;&gt; <a href="https://readingstori.es">readingstori.es</a> -- books for a baby, semantic HTML experiment
   &gt;&gt; <a href="https://lloydcenter.fun">lloydcenter.fun</a> -- fan page for Portland's gloriously weird half-empty mall
+  &gt;&gt; <a href="https://wiki-hn.com">wiki-hn.com</a> -- Wikipedia articles that blew up on Hacker News
 </pre>
                         <center>
                             <a
@@ -189,7 +190,8 @@
         <script>
             var members = [
                 "https://readingstori.es",
-                "https://lloydcenter.fun"
+                "https://lloydcenter.fun",
+                "https://wiki-hn.com"
             ];
             var n = members.length;
             document.getElementById("member-count").textContent = n + (n === 1 ? " member" : " members");


### PR DESCRIPTION
## Summary
- Adds [wiki-hn.com](https://wiki-hn.com) to the members list and JS array
- Wikipedia articles that blew up on Hacker News, ranked by points
- Webring snippet already added to the site

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)